### PR TITLE
Set max-height for the legend

### DIFF
--- a/src/common/legend/style/legend.less
+++ b/src/common/legend/style/legend.less
@@ -13,6 +13,10 @@
   max-height: 100%;
   /*overflow-y: auto;*/
   visibility: hidden;
+  .panel {
+    max-height: 450px;
+    overflow-y: scroll;
+  }
 }
 
 .legend-panel-body {


### PR DESCRIPTION
## What does this PR do?

Sets the max-height for the legend.
When the view is embedded the legend should not flow beyond the height so
set the height to the default embed size 450
### Related Issue

[#1306](https://github.com/MapStory/mapstory/issues/1306) entry number one
