### PR TITLE
Allow different OSM Layers

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -484,7 +484,9 @@ var SERVER_SERVICE_USE_PROXY = true;
             server.name = 'OpenStreetMap';
           }
           server.layersConfig = [
-            {Title: 'OpenStreetMap', Name: 'mapnik'}
+            {Title: 'OpenStreetMap', Name: 'mapnik'},
+            {Title: 'HOT OSM', Name: 'hot',
+              sourceParams: {url: 'http://tile-{a-c}.openstreetmap.fr/hot/{z}/{x}/{y}.png'}}
           ];
           deferredResponse.resolve(server);
         } else if (server.ptype === 'gxp_mapboxsource') {

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -574,9 +574,9 @@
         });
       } else {
         if (server.ptype === 'gxp_osmsource') {
-          sourceParams = {};
+          var osmParams = {};
           if (goog.isDefAndNotNull(fullConfig.sourceParams)) {
-            goog.object.extend(sourceParams, fullConfig.sourceParams);
+            goog.object.extend(osmParams, fullConfig.sourceParams);
           }
           layer = new ol.layer.Tile({
             metadata: {
@@ -585,7 +585,7 @@
               title: fullConfig.Title
             },
             visible: minimalConfig.visibility,
-            source: new ol.source.OSM(sourceParams)
+            source: new ol.source.OSM(osmParams)
           });
         } else if (server.ptype === 'gxp_bingsource') {
 

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -574,6 +574,10 @@
         });
       } else {
         if (server.ptype === 'gxp_osmsource') {
+          sourceParams = {};
+          if (goog.isDefAndNotNull(fullConfig.sourceParams)) {
+            goog.object.extend(sourceParams, fullConfig.sourceParams);
+          }
           layer = new ol.layer.Tile({
             metadata: {
               serverId: server.id,
@@ -581,7 +585,7 @@
               title: fullConfig.Title
             },
             visible: minimalConfig.visibility,
-            source: new ol.source.OSM()
+            source: new ol.source.OSM(sourceParams)
           });
         } else if (server.ptype === 'gxp_bingsource') {
 


### PR DESCRIPTION
## What does this PR do?

Allows the addition of different OSM layer and adds the HOT OSM layer to OSM layers.

Add ability to add sourceParams to OSM layers by specifying the URL we can add different OSM layers.
### Related Issue

fixes [#1336](https://github.com/MapStory/mapstory/issues/1336)
### Screenshot

<img width="594" alt="bildschirmfoto 2016-02-29 um 14 02 11" src="https://cloud.githubusercontent.com/assets/688980/13395131/0f1e8878-deed-11e5-9790-d0a7460e3a7b.png">
