### PR TITLE
MSSS 41 #1: Layer Styling Persistence

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -25,6 +25,8 @@
   module.controller('AppCtrl', function AppCtrl($rootScope, $scope, $window, $location, $translate, mapService, debugService,
                                                 refreshService, dialogService, historyService, storyService, boxService, pinService, $http, layerService, serverService) {
 
+        $scope.activeChapterId = 0;
+
         $scope.$on('$stateChangeSuccess', function(event, toState) {
           if (angular.isDefined(toState.data.pageTitle)) {
             $scope.pageTitle = toState.data.pageTitle;
@@ -40,8 +42,10 @@
           }
         });
 
-        $scope.$on('chapter-switch', function(event) {
+        $scope.$on('chapter-switch', function(event, chapterId) {
           if (goog.isDefAndNotNull($scope.mapService)) {
+            console.log('!DJA chapter switch to ' + chapterId);
+            $scope.activeChapterId = chapterId;
             $scope.storyLayers = $scope.mapService.getStoryLayers(true, true);
           }
         });
@@ -234,9 +238,9 @@
 
         $scope.styleChanged = function(layer) {
           layer.on('change:type', function(evt) {
-            mapService.updateStyle(evt.target);
+            mapService.updateStyle(evt.target, $scope.activeChapterId);
           });
-          mapService.updateStyle(layer);
+          mapService.updateStyle(layer, $scope.activeChapterId);
         };
 
         $scope.updateTourStep = function(step) {

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -25,6 +25,8 @@
   module.controller('AppCtrl', function AppCtrl($rootScope, $scope, $window, $location, $translate, mapService, debugService,
                                                 refreshService, dialogService, historyService, storyService, boxService, pinService, $http, layerService, serverService) {
 
+        $scope.activeChapterId = 0;
+
         $scope.$on('$stateChangeSuccess', function(event, toState) {
           if (angular.isDefined(toState.data.pageTitle)) {
             $scope.pageTitle = toState.data.pageTitle;
@@ -40,8 +42,9 @@
           }
         });
 
-        $scope.$on('chapter-switch', function(event) {
+        $scope.$on('chapter-switch', function(event, chapterId) {
           if (goog.isDefAndNotNull($scope.mapService)) {
+            $scope.activeChapterId = chapterId;
             $scope.storyLayers = $scope.mapService.getStoryLayers(true, true);
           }
         });
@@ -234,9 +237,9 @@
 
         $scope.styleChanged = function(layer) {
           layer.on('change:type', function(evt) {
-            mapService.updateStyle(evt.target);
+            mapService.updateStyle(evt.target, $scope.activeChapterId);
           });
-          mapService.updateStyle(layer);
+          mapService.updateStyle(layer, $scope.activeChapterId);
         };
 
         $scope.updateTourStep = function(step) {

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -864,6 +864,14 @@
               }
 
               var styles = [];
+              var paramStyles = null;
+
+              var layerParams = {
+                LAYERS: minimalConfig.name,
+                tiled: 'true',
+                wrapX: false
+              };
+
               if (goog.isDefAndNotNull(fullConfig.Layer[0].Style)) {
                 console.log('config style', fullConfig.Layer[0].Style);
                 for (var index = 0; index < fullConfig.Layer[0].Style.length; index++) {
@@ -874,6 +882,12 @@
                     abstract: style.Abstract,
                     legendUrl: style.LegendURL[0].OnlineResource
                   });
+                  paramStyles = service_.configuration.username + '-' +
+                                service_.configuration.id + '-simple-' + style.Name +
+                                '-' + minimalConfig.name.split(':')[1]; //'admin-0-simple-line-lewisclark',
+                  if (service_.configuration.id !== 0) {
+                    layerParams['STYLES'] = paramStyles;
+                  }
                 }
               }
 
@@ -899,11 +913,7 @@
                 visible: minimalConfig.visibility,
                 source: new ol.source.TileWMS({
                   url: mostSpecificUrlWms,
-                  params: {
-                    'LAYERS': minimalConfig.name,
-                    'tiled': 'true',
-                    wrapX: false
-                  }
+                  params: layerParams
                 })
               });
 


### PR DESCRIPTION
This PR:
- Applies user defined layer styling from a previous MapStory session if it exists. Ie, if a user opens a new map, adds a layer, styles it, saves it, exits the map, and reopens the map, the styling they applied in the previous session will persist.
- Stores json styling data for layers in the window config so that it can be retrieved by Story-tools and used to populate the style editor. A Story-tools PR that utilizes this is forthcoming.
