### PR TITLE
Update legend on style change.

### DIFF
--- a/src/common/legend/LegendDirective.js
+++ b/src/common/legend/LegendDirective.js
@@ -39,18 +39,7 @@
               }
             };
 
-            scope.getLegendUrl = function(layer) {
-              var url = null;
-              var server = serverService.getServerById(layer.get('metadata').serverId);
-              url = server.url + '?request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=' +
-                  layer.get('metadata').name + '&transparent=true&legend_options=fontColor:0xFFFFFF;' +
-                  'fontAntiAliasing:true;fontSize:14;fontStyle:bold;';
-              if (goog.isDefAndNotNull(layer.get('metadata').config.styles)) {
-                url += '&style=' + layer.get('metadata').config.styles;
-                //url += '&_ts=' + new Date().getTime();
-              }
-              return url;
-            };
+            scope.getLegendUrl = scope.mapService.getLegendUrl;
 
             scope.$on('layer-added', function() {
               if (legendOpen === false) {

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -17,6 +17,7 @@
   var q_ = null;
   var mousePositionControl_ = null;
   var showTimeline_ = false;
+  var layerStyleTimeStamps = {};
 
   var select = null;
   var draw = null;
@@ -242,6 +243,24 @@
 
 
       return this;
+    };
+
+    this.getLegendUrl = function(layer) {
+      var url = null;
+      var _ts = new Date().getTime();
+      if (!layerStyleTimeStamps[layer.get('metadata').name] ||
+          _ts - layerStyleTimeStamps[layer.get('metadata').name] > 150) {
+        layerStyleTimeStamps[layer.get('metadata').name] = _ts;
+      }
+      var server = serverService_.getServerById(layer.get('metadata').serverId);
+      url = server.url + '?test=ab&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=' +
+          layer.get('metadata').name + '&transparent=true&legend_options=fontColor:0xFFFFFF;' +
+          'fontAntiAliasing:true;fontSize:14;fontStyle:bold;';
+      if (goog.isDefAndNotNull(layer.get('metadata').config.styles)) {
+        url += '&style=' + layer.get('metadata').config.styles;
+        url += '&_ts=' + layerStyleTimeStamps[layer.get('metadata').name];
+      }
+      return url;
     };
 
     this.activateDragZoom = function() {


### PR DESCRIPTION
This PR updates the legend icon when a style for a layer is changed. Since `getLegendUrl` gets called continuously by the legend directive, adding a timestamp to the legend url in order to cache bust it causes errors during Angular's digest step -- the url changes before the loop completes. The method used here associates a timestamp with a layer's name in the `layerStyleTimeStamps` object, and only applies a new timestamp if 150 milliseconds have passed, giving the digest loop time to complete before the url is changed.

Also, I moved the `getLegendUrl` into the map service rather than having it live in a directive.