### PR TITLE
Add Angular redirect function for external links

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -195,6 +195,10 @@
         $scope.menuSection = 'mainMenu';
         $scope.storyLayers = mapService.getStoryLayers();
 
+        $scope.redirect = function(address) {
+          window.top.location.href = address;
+        };
+
         $scope.updateMenuSection = function(updateMenuSection) {
           if (updateMenuSection == 'mainMenuHidden') {
             $scope.prev_menu_section = $scope.menuSection;

--- a/src/common/sidebar/partials/mainMenuTop.tpl.html
+++ b/src/common/sidebar/partials/mainMenuTop.tpl.html
@@ -1,10 +1,11 @@
 <div id="composerTopNav" class="ng-scope" style="padding-bottom: 5px;">
   <span id="topNavContentWrapper">
     <p id="siteNameWrapper">
-      <i class="fa fa-home" href="/"></i> {{ application.name }}
+      <i class="fa fa-home" ng-click="redirect('/')" href></i> {{ application.name }}
     </p>
     <p id="usernameWrapper">
-      <small style="font-size: 12px;font-weight: 300;">
+      <small style="cursor:pointer" ng-click="redirect('/storyteller/' + storyService.username)"
+             style="font-size: 12px;font-weight: 300;">
         @{{ storyService.username }}
       </small>
     </p>


### PR DESCRIPTION
This PR creates an application level redirect function to be used in place of html links, since the iframe has to target the parent window. This method gets applied to the "Home" button and "@{{user}}" button in Composer. These link to the home page and user profile page respectively. 