### PR TITLE
Remove View History Breadcrumbs

### DIFF
--- a/src/common/sidebar/partials/viewLayerHistory.tpl.html
+++ b/src/common/sidebar/partials/viewLayerHistory.tpl.html
@@ -1,4 +1,3 @@
-<div class="topText"><a href="#" ng-click="updateMenuSection('mainMenu')">{{ 'Index' | translate:'Index' }}</a> > <a href="#" ng-click="updateMenuSection('selectedChapter' + chapter.id)">{{ chapter.chapter }}</a></div>
 <div class="bottomText">{{ storyService.active_layer.get('metadata').title }} History</div>
 
 <div class="menuItem">

--- a/src/common/sidebar/partials/viewSingleLayerHistory.tpl.html
+++ b/src/common/sidebar/partials/viewSingleLayerHistory.tpl.html
@@ -1,5 +1,3 @@
-<div class="topText"><a href="#" ng-click="updateMenuSection('mainMenu')">{{ 'Index' | translate:'Index' }}</a> > <a href="#" ng-click="updateMenuSection('selectedChapter' + chapter.id)">{{ chapter.chapter }}</a></div>
-
 <h2>{{ storyService.active_chapter.about.title }}</h2>
 <h2>{{ storyService.active_layer.get('metadata').title }} History</h2>
 <div class="menuItem">


### PR DESCRIPTION
Remove the breadcrumbs from the edit history view so that users can’t click out of the edit view to Composer.