### PR TITLE
Remove storypin pause playback options from Composer

### DIFF
--- a/src/common/sidebar/partials/addStoryPin.tpl.html
+++ b/src/common/sidebar/partials/addStoryPin.tpl.html
@@ -58,16 +58,10 @@
             <input id="in_timeline" type="checkbox" ng-init="pin.in_timeline = false" ng-model="pin.in_timeline"> In timeline</input>
         </div>
     </div>
-     <div class="form-group">
-        <label for="pause_playback">Pause playback of timeline</label>
-        <div>
-            <input id="pause_playback" type="checkbox" ng-init="pin.pause_playback = false" ng-model="pin.pause_playback"> Pause playback </input>
-        </div>
-    </div>
     <div class="form-group">
         <label for="auto_show">Automatically Show Content</label>
         <div>
-            <input id="auto_show" type="checkbox" ng-init="pin.auto_show = false" ng-model="pin.auto_show"> Show Content </input>
+            <input id="auto_show" type="checkbox" ng-init="pin.auto_show = false" ng-model="pin.auto_show"> Show content </input>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This PR addresses https://github.com/MapStory/mapstory/issues/414

NOTE: if the pause playback setting is still visible, we may have to go onto the server and manually remove L1762-1767 of `templates-common.js`; or fix the Grunt build to do this for us. It looks like it should build the compiled templates correctly in the Gruntfile, but wasn't working for me locally. 