### PR TITLE
Update favorites API

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -633,7 +633,7 @@ var SERVER_SERVICE_USE_PROXY = true;
     };
 
     this.addSearchResultsForFavorites = function(server, filterOptions) {
-      var searchUrl = '/api/favorites/?content_type=42&limit=100';
+      var searchUrl = '/api/favorites/?type=layer&limit=100';
       if (filterOptions !== null) {
         searchUrl = applyFavoritesFilter(searchUrl, filterOptions);
       }

--- a/src/common/addlayers/ServerServiceSpec.js
+++ b/src/common/addlayers/ServerServiceSpec.js
@@ -208,7 +208,7 @@ describe('addLayers/ServerService', function() {
     });
     describe('server is available and returns results', function() {
       beforeEach(function() {
-        $httpBackend.expect('GET', '/api/favorites/?content_type=42&limit=100').respond(200, []);
+        $httpBackend.expect('GET', '/api/favorites/?type=layer&limit=100').respond(200, []);
       });
       it('reformats the Layer configs based on the server data', function() {
         spyOn(serverService, 'reformatConfigForFavorites');
@@ -225,7 +225,7 @@ describe('addLayers/ServerService', function() {
     });
     describe('search server is invalid', function() {
       beforeEach(function() {
-        $httpBackend.expect('GET', '/api/favorites/?content_type=42&limit=100').respond(501, []);
+        $httpBackend.expect('GET', '/api/favorites/?type=layer&limit=100').respond(501, []);
       });
       it('reformats the Layer configs based on the server data', function() {
         spyOn(serverService, 'reformatConfigForFavorites');
@@ -236,7 +236,7 @@ describe('addLayers/ServerService', function() {
     });
     describe('filter for title', function() {
       it('returns the url with title__contains', function() {
-        $httpBackend.expect('GET', '/api/favorites/?content_type=42&limit=100&title__contains=Dijkstra').respond(200, []);
+        $httpBackend.expect('GET', '/api/favorites/?type=layer&limit=100&title__contains=Dijkstra').respond(200, []);
         spyOn(serverService, 'reformatConfigForFavorites');
         var filterOptions = {
           owner: null,


### PR DESCRIPTION
Update favorites API in the mini explore so that it doesn’t use hard coded content type number which may not always be the same.