### PR TITLE
Resolve mapstory#1038

### DIFF
--- a/src/common/story/StoryService.js
+++ b/src/common/story/StoryService.js
@@ -449,8 +449,6 @@
       this.active_chapter = this.configurations[index];
       this.active_index = index;
 
-      console.log(' !DJA: ACTIVE CONFIG ----- >', this.active_chapter);
-
       mapService_.updateActiveMap(this.active_index, this.active_chapter);
       rootScope_.$broadcast('chapter-switch', this.active_index);
     };

--- a/src/common/story/StoryService.js
+++ b/src/common/story/StoryService.js
@@ -104,12 +104,12 @@
       });
 
       rootScope_.$on('chapter-switch', function(event, active_index) {
-        if (goog.isDefAndNotNull(service_.configurations[active_index].zoom) && goog.isDefAndNotNull(service_.configurations[active_index].center)) {
+        if (goog.isDefAndNotNull(service_.configurations[active_index].map.zoom) && goog.isDefAndNotNull(service_.configurations[active_index].map.center)) {
           var pan = ol.animation.pan({source: mapService_.map.getView().getCenter()});
           var zoom = ol.animation.zoom({resolution: mapService_.map.getView().getResolution()});
           mapService_.map.beforeRender(pan, zoom);
-          mapService_.map.getView().setCenter(service_.configurations[active_index].center);
-          mapService_.map.getView().setZoom(service_.configurations[active_index].zoom);
+          mapService_.map.getView().setCenter(service_.configurations[active_index].map.center);
+          mapService_.map.getView().setZoom(service_.configurations[active_index].map.zoom);
         } else {
           mapService_.zoomToLargestStoryLayer();
         }
@@ -448,6 +448,8 @@
       }
       this.active_chapter = this.configurations[index];
       this.active_index = index;
+
+      console.log(' !DJA: ACTIVE CONFIG ----- >', this.active_chapter);
 
       mapService_.updateActiveMap(this.active_index, this.active_chapter);
       rootScope_.$broadcast('chapter-switch', this.active_index);


### PR DESCRIPTION
Fixes chapter default zoom. The attributes `center` and `zoom` belong to the active config `map` object, not the active config itself. 