### PR TITLE
Disable Haystack

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -629,7 +629,7 @@ var SERVER_SERVICE_USE_PROXY = true;
     };
 
     this.populateLayersConfigElastic = function(server, filterOptions) {
-      var searchUrl = '/api/layers/search/?limit=100';
+      var searchUrl = '/api/base/?type=layer&limit=100';
       if (filterOptions !== null) {
         searchUrl = service_.applyESFilter(searchUrl, filterOptions);
       }

--- a/src/common/addlayers/ServerServiceSpec.js
+++ b/src/common/addlayers/ServerServiceSpec.js
@@ -115,7 +115,7 @@ describe('addLayers/ServerService', function() {
     describe('server is available and returns results', function() {
       beforeEach(function() {
         $httpBackend.resetExpectations();
-        $httpBackend.expect('GET', '/api/layers/search/?is_published=true&limit=100').respond(200, []);
+        $httpBackend.expect('GET', '/api/base/?type=layer&is_published=true&limit=100').respond(200, []);
       });
       it('reformats the Layer configs based on the server data', function() {
         spyOn(serverService, 'reformatLayerConfigs');
@@ -132,7 +132,7 @@ describe('addLayers/ServerService', function() {
     });
     describe('search server is invalid', function() {
       beforeEach(function() {
-        $httpBackend.expect('GET', '/api/layers/search/?is_published=true&limit=100').respond(500, '');
+        $httpBackend.expect('GET', '/api/base/?type=layer&is_published=true&limit=100').respond(500, '');
       });
       it('reformats the Layer configs based on the server data', function() {
         spyOn(serverService, 'reformatLayerConfigs');

--- a/src/common/addlayers/partials/addlayers.tpl.html
+++ b/src/common/addlayers/partials/addlayers.tpl.html
@@ -27,7 +27,7 @@
                             </nav>
                             <div class="clearfix search-results">
                                 <div class="col-sm-3 cards"
-                                     ng-repeat="layer in layersConfig = serverService.getLayersConfigByName('Local Geoserver') | filter:filterLayers | filter:filterAddedLayers">
+                                     ng-repeat="layer in layersConfig = serverService.getLayersConfigByName('Local Geoserver')">
                                     <div class="cards-body">
                                         <img class="img-responsive" ng-src="{{layer.thumbnail_url}}" height="150" width="200">
                                         <h4>{{ layer.Title }}</h4>


### PR DESCRIPTION
Changes MapLoom to use the standard django API routes instead of Haystack and removes filtering that was breaking without elasticsearch / haystack.