### PR TITLE
886 reduce date fields

### DIFF
--- a/src/common/featuremanager/AttributeEditDirective.js
+++ b/src/common/featuremanager/AttributeEditDirective.js
@@ -57,7 +57,6 @@
                     }
                   }
                 }
-                console.log('!!!PROPS:!!!', scope.properties);
               }
 
               if (geometry.type.toLowerCase() == 'point') {

--- a/src/common/featuremanager/AttributeEditDirective.js
+++ b/src/common/featuremanager/AttributeEditDirective.js
@@ -43,9 +43,21 @@
 
                 for (var propName in attributeTypes) {
                   if (tempProperties.hasOwnProperty(propName)) {
-                    scope.properties.push(tempProperties[propName]);
+                    var renameFields = ['begindate_xd', 'enddate_xd'];
+                    var hiddenFields = ['begindate_parsed', 'enddate_parsed', 'begindate', 'enddate', 'start_parsed'];
+                    if (!hiddenFields.includes(tempProperties[propName][0])) {
+                      scope.properties.push(tempProperties[propName]);
+                      if (renameFields.includes(tempProperties[propName][0])) {
+                        var pattern = /_xd/i;
+                        tempProperties[propName][0] = tempProperties[propName][0].replace(pattern, '');
+                        if (!scope.properties.includes(tempProperties[propName])) {
+                          scope.properties.push(tempProperties[propName]);
+                        }
+                      }
+                    }
                   }
                 }
+                console.log('!!!PROPS:!!!', scope.properties);
               }
 
               if (geometry.type.toLowerCase() == 'point') {

--- a/src/common/timeline/TimelineService.js
+++ b/src/common/timeline/TimelineService.js
@@ -285,15 +285,17 @@
           // remove old tick marks if changes to the feature doesn't leave any feature for that time slice.
           var foundOldTick = false;
           for (i = 0; i < changedAttributesOld.length; i++) {
-            attributeType = metadata.schema[changedAttributesOld[i][0]]._type.toLowerCase();
-            if (attributeType.indexOf('date') !== -1 || attributeType.indexOf('time') !== -1) {
-              if (changedAttributesOld[i][1] in timelineTicksMap_) {
-                foundOldTick = true;
-                if (timelineTicksMap_[changedAttributesOld[i][1]] > 1) {
-                  timelineTicksMap_[changedAttributesOld[i][1]] -= 1;
-                } else {
-                  ticksChanged = true;
-                  delete timelineTicksMap_[changedAttributesOld[i][1]];
+            if (metadata.schema[changedAttributesOld[i][0]]) {
+              attributeType = metadata.schema[changedAttributesOld[i][0]]._type.toLowerCase();
+              if (attributeType.indexOf('date') !== -1 || attributeType.indexOf('time') !== -1) {
+                if (changedAttributesOld[i][1] in timelineTicksMap_) {
+                  foundOldTick = true;
+                  if (timelineTicksMap_[changedAttributesOld[i][1]] > 1) {
+                    timelineTicksMap_[changedAttributesOld[i][1]] -= 1;
+                  } else {
+                    ticksChanged = true;
+                    delete timelineTicksMap_[changedAttributesOld[i][1]];
+                  }
                 }
               }
             }


### PR DESCRIPTION
1. AttributeEditDirective.js: Added logic to 'loomAttributeEdit' directive to filter, remove non begin, end '_xd' date fields from the Edit Attributes modal. Added regex to remove '_xd' from from form labels. 
2. TimelineService.js: Added is defined logic to endAttributeEdit function.
