### PR TITLE
Add handling for proxying service urls to support pki protected services

### DIFF
--- a/src/common/utils/Globals.js
+++ b/src/common/utils/Globals.js
@@ -9,7 +9,11 @@ var settings = {
   DDPrecision: 8,
   WFSVersion: '1.1.0',
   WMSVersion: '1.1.1',
-  WPSVersion: '1.0.0'
+  WPSVersion: '1.0.0',
+  //Set to OsmLocalUrl to 'default' for default mapnick osm basemap
+  OsmLocalUrl: 'default',
+  //OsmLocalUrl: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png',
+  OsmLocalAttribution: 'All maps &copy; <a href="http://www.opencyclemap.org/">OpenCycleMap</a>'
 };
 
 var forEachArrayish = function(arrayish, funct) {
@@ -346,4 +350,22 @@ var removeUrlLastRoute = function(urlWithRoutes) {
   }
 
   return newUrl;
+};
+
+// Proxy the domain if appropriate
+var getUseProxyParam = function(server) {
+  return goog.isDefAndNotNull(server.use_proxy) ? server.use_proxy : false;
+};
+
+// proxy a url if the source parameters indicate to do so
+var useProxyUrlParam = function(use_proxy, url, configService) {
+  if (goog.isDefAndNotNull(use_proxy) && goog.isDefAndNotNull(configService) && use_proxy === true) {
+    url = decodeURIComponent(url);
+    if (url.indexOf(configService.configuration.proxy) < 0) {
+      url = configService.configuration.proxy + encodeURIComponent(url);
+    } else {
+      url = encodeURIComponent(url);
+    }
+  }
+  return url;
 };

--- a/src/index.html
+++ b/src/index.html
@@ -38,7 +38,7 @@
             currentLanguage: "{{language|default:'en'}}",
             userprofilename: {% if user.is_authenticated %} "{{ user.get_full_name }}" {% else %} undefined {% endif %},
             userprofileemail: {% if user.is_authenticated %} "{{ user.email }}" {% else %} undefined {% endif %},
-            proxy: "/proxy/?url=",
+            proxy: "{{ PROXY_URL }}" !== '' ? "{{ PROXY_URL }}" : "/proxy/?url=",
             nominatimUrl: "http://nominatim.openstreetmap.org",
             printService: "{{GEOSERVER_BASE_URL}}pdf/",
             /* The URL to a REST map configuration service.  This service


### PR DESCRIPTION
Note: The "TODO"s marked in the code stem from some unanswered questions I had from the first time implementing the PKI proxy in MapLoom. The essential two (wms and arcrest services) should go through the proxy just fine.